### PR TITLE
Add texture atlas support and sample block textures in renderer

### DIFF
--- a/src/main/java/org/aouessar/core/mesh/GreedyMesher.java
+++ b/src/main/java/org/aouessar/core/mesh/GreedyMesher.java
@@ -155,6 +155,13 @@ public final class GreedyMesher implements Mesher {
         if (materialId == BlockId.GRASS) {
             boolean isTopFace = (d == 1) && positive; // +Y
             if (!isTopFace) {
+                materialId = BlockId.GRASS_SIDE;
+            }
+        }
+
+        if (materialId == BlockId.GRASS_SIDE) {
+            boolean isBottomFace = (d == 1) && !positive;
+            if (isBottomFace) {
                 materialId = BlockId.DIRT;
             }
         }

--- a/src/main/java/org/aouessar/core/streaming/FarTileBuilder.java
+++ b/src/main/java/org/aouessar/core/streaming/FarTileBuilder.java
@@ -59,12 +59,8 @@ final class FarTileBuilder {
                 pos.add((float) h - FAR_Y_BIAS);
                 pos.add((float) wz);
 
-                // biome noise in uv.x, normalized height in uv.y
-                float biome = biomeNoise01(wx >> FAR_BIOME_SHIFT, wz >> FAR_BIOME_SHIFT); // 0..1
-                float hNorm = clamp01((h - FAR_HEIGHT_NORM_MIN) / FAR_HEIGHT_NORM_RANGE); // 0..1
-
-                uv.add(biome);
-                uv.add(hNorm);
+                uv.add((float) wx);
+                uv.add((float) wz);
 
                 short topMat;
                 if (h <= seaLevel) {
@@ -227,16 +223,4 @@ final class FarTileBuilder {
         }
     }
 
-    private static float clamp01(float v) {
-        return v < 0f ? 0f : (v > 1f ? 1f : v);
-    }
-
-    // Fast deterministic hash noise (value noise-ish), good enough for biomes
-    private static float biomeNoise01(int x, int z) {
-        int n = x * 374761393 + z * 668265263; // large primes
-        n = (n ^ (n >> 13)) * 1274126177;
-        n = n ^ (n >> 16);
-        // convert to 0..1
-        return (n & 0x7fffffff) / 2147483647.0f;
-    }
 }

--- a/src/main/java/org/aouessar/core/world/BlockId.java
+++ b/src/main/java/org/aouessar/core/world/BlockId.java
@@ -17,4 +17,6 @@ public final class BlockId {
     public static final short SAND = 5;
 
     public static final short SNOW = 6;
+
+    public static final short GRASS_SIDE = 7;
 }

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
@@ -21,6 +21,7 @@ public final class GlRenderer {
     private final long window;
     private final FlyCamera camera = new FlyCamera();
     private final ShaderProgram shader;
+    private final GlTexture atlasTexture;
     private int width = 1280, height = 720;
 
     // World (core)
@@ -53,6 +54,8 @@ public final class GlRenderer {
     private float camVx, camVz;
     private float camSpeed;
 
+    private static final int MAX_MATERIALS = 16;
+
     // ---- NEW: Near coverage set (chunk columns cx,cz currently present on GPU) ----
     // Rebuilt every frame from gpuMeshes.keySet() so it never becomes "sticky".
     private final LongSet nearColumns = new LongSet(1 << 16);
@@ -63,6 +66,13 @@ public final class GlRenderer {
         glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
         shader = new ShaderProgram(VS, FS);
+        atlasTexture = new GlTexture("/atlas.png", true);
+
+        TextureAtlas atlas = TextureAtlas.load("/atlas.json");
+        float[] atlasRects = buildAtlasRects(atlas);
+        shader.use();
+        shader.setInt("uAtlas", 0);
+        shader.setVec4Array("uAtlasRects", atlasRects, MAX_MATERIALS);
 
         glfwSetFramebufferSizeCallback(window, (w, newW, newH) -> {
             width = Math.max(newW, 1);
@@ -168,6 +178,7 @@ public final class GlRenderer {
 
         // 4) Render
         shader.use();
+        atlasTexture.bind(0);
         float aspect = (float) width / (float) height;
         Mat4 proj = Mat4.perspective((float) Math.toRadians(75.0), aspect, 0.1f, 5000f);
         Mat4 view = camera.viewMatrix();
@@ -177,8 +188,6 @@ public final class GlRenderer {
 
         shader.setMat4("uVP", vp.m);
         shader.setVec3("uCameraPos", camera.position.x, camera.position.y, camera.position.z);
-        shader.setFloat("uSeaLevel", SEA_LEVEL);
-        shader.setFloat("uMaxHeight", WORLD_MAX_Y);
 
         // ---- NEW: rebuild near coverage columns from CURRENT gpuMeshes ----
         // This is the key to avoiding holes and avoiding "missing far after near".
@@ -467,8 +476,40 @@ public final class GlRenderer {
         for (GlMesh m : gpuMeshes.values()) m.dispose();
         gpuMeshes.clear();
 
+        atlasTexture.dispose();
         shader.dispose();
         world.shutdown();
+    }
+
+    private static float[] buildAtlasRects(TextureAtlas atlas) {
+        float[] rects = new float[MAX_MATERIALS * 4];
+
+        TextureAtlas.Region fallback = atlas.region("dirt");
+        TextureAtlas.Region grass = atlas.regionOrDefault("grass", fallback);
+        TextureAtlas.Region grassSide = atlas.regionOrDefault("grass_side", grass);
+        TextureAtlas.Region stone = atlas.regionOrDefault("stone", fallback);
+        TextureAtlas.Region sand = atlas.regionOrDefault("sand", fallback);
+        TextureAtlas.Region snow = atlas.regionOrDefault("snow", grass);
+        TextureAtlas.Region water = atlas.regionOrDefault("water", atlas.regionOrDefault("glass", fallback));
+
+        setRegion(rects, BlockId.AIR, fallback);
+        setRegion(rects, BlockId.GRASS, grass);
+        setRegion(rects, BlockId.DIRT, fallback);
+        setRegion(rects, BlockId.STONE, stone);
+        setRegion(rects, BlockId.WATER, water);
+        setRegion(rects, BlockId.SAND, sand);
+        setRegion(rects, BlockId.SNOW, snow);
+        setRegion(rects, BlockId.GRASS_SIDE, grassSide);
+
+        return rects;
+    }
+
+    private static void setRegion(float[] rects, int materialId, TextureAtlas.Region region) {
+        int base = materialId * 4;
+        rects[base] = region.u0();
+        rects[base + 1] = region.v0();
+        rects[base + 2] = region.u1();
+        rects[base + 3] = region.v1();
     }
 
     private static final String VS = """
@@ -502,46 +543,11 @@ public final class GlRenderer {
         in vec2 vUv;
         flat in float vMat;
 
+        uniform sampler2D uAtlas;
+        uniform vec4 uAtlasRects[16];
         uniform vec3 uCameraPos;
-        uniform float uSeaLevel;
-        uniform float uMaxHeight;
 
         out vec4 FragColor;
-
-        float hash12(vec2 p) {
-            float h = dot(p, vec2(127.1, 311.7));
-            return fract(sin(h) * 43758.5453123);
-        }
-
-        vec3 materialColor(float id, float hNorm, float biome) {
-            float mid = abs(id);
-
-            if (mid < 0.5) return vec3(0.0);
-
-            if (mid < 1.5) { // GRASS
-                vec3 plains   = vec3(0.18, 0.70, 0.24);
-                vec3 forest   = vec3(0.10, 0.45, 0.14);
-                vec3 mountain = vec3(0.55, 0.55, 0.58);
-                vec3 snow     = vec3(0.92, 0.92, 0.95);
-
-                vec3 base = mix(plains, forest, biome);
-
-                float m = smoothstep(0.55, 0.75, hNorm);
-                base = mix(base, mountain, m);
-
-                float s = smoothstep(0.78, 0.92, hNorm);
-                base = mix(base, snow, s);
-
-                return base;
-            }
-
-            if (mid < 2.5) return vec3(0.50, 0.32, 0.16); // DIRT
-            if (mid < 3.5) return vec3(0.62, 0.62, 0.66); // STONE
-            if (mid < 4.5) return vec3(0.10, 0.35, 0.75); // WATER
-            if (mid < 5.5) return vec3(0.78, 0.72, 0.45); // SAND
-
-            return vec3(1.0, 0.0, 1.0);
-        }
 
         void main() {
             vec3 n = normalize(vNrm);
@@ -552,11 +558,13 @@ public final class GlRenderer {
             float upness = clamp(dot(n, vec3(0,1,0)), 0.0, 1.0);
             float slopeDark = mix(0.65, 1.0, upness);
 
-            float hNorm = clamp((vWorldPos.y - uSeaLevel) / (uMaxHeight - uSeaLevel), 0.0, 1.0);
-            vec2 bCell = floor(vWorldPos.xz / 128.0);
-            float biome = hash12(bCell);
+            int mat = int(vMat + 0.5);
+            mat = clamp(mat, 0, 15);
+            vec4 rect = uAtlasRects[mat];
+            vec2 uv = mix(rect.xy, rect.zw, fract(vUv));
+            vec3 baseColor = texture(uAtlas, uv).rgb;
 
-            vec3 color = materialColor(vMat, hNorm, biome) * ndl * slopeDark;
+            vec3 color = baseColor * ndl * slopeDark;
 
             float dist = length(vWorldPos - uCameraPos);
             float camAlt = uCameraPos.y;

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
@@ -66,7 +66,7 @@ public final class GlRenderer {
         glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
         shader = new ShaderProgram(VS, FS);
-        atlasTexture = new GlTexture("/atlas.png", true);
+        atlasTexture = new GlTexture("/atlas.png", false);
 
         TextureAtlas atlas = TextureAtlas.load("/atlas.json");
         float[] atlasRects = buildAtlasRects(atlas);

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
@@ -66,7 +66,7 @@ public final class GlRenderer {
         glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
         shader = new ShaderProgram(VS, FS);
-        atlasTexture = new GlTexture("/atlas.png", false);
+        atlasTexture = new GlTexture("/atlas.png", true);
 
         TextureAtlas atlas = TextureAtlas.load("/atlas.json");
         float[] atlasRects = buildAtlasRects(atlas);

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/GlRenderer.java
@@ -561,7 +561,13 @@ public final class GlRenderer {
             int mat = int(vMat + 0.5);
             mat = clamp(mat, 0, 15);
             vec4 rect = uAtlasRects[mat];
-            vec2 uv = mix(rect.xy, rect.zw, fract(vUv));
+
+            vec2 tileUv = vUv;
+            if (any(greaterThan(abs(vUv), vec2(1.0)))) {
+                tileUv = fract(vUv);
+            }
+
+            vec2 uv = mix(rect.xy, rect.zw, tileUv);
             vec3 baseColor = texture(uAtlas, uv).rgb;
 
             vec3 color = baseColor * ndl * slopeDark;

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/GlTexture.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/GlTexture.java
@@ -1,0 +1,71 @@
+package org.aouessar.platform.lwjgl.renderer;
+
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+import static org.lwjgl.opengl.GL33.*;
+import static org.lwjgl.system.MemoryUtil.memAlloc;
+import static org.lwjgl.system.MemoryUtil.memFree;
+
+final class GlTexture {
+    private final int id;
+
+    GlTexture(String resourcePath, boolean flipVertically) {
+        ByteBuffer image = loadResource(resourcePath);
+
+        STBImage.stbi_set_flip_vertically_on_load(flipVertically);
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer width = stack.mallocInt(1);
+            IntBuffer height = stack.mallocInt(1);
+            IntBuffer channels = stack.mallocInt(1);
+
+            ByteBuffer data = STBImage.stbi_load_from_memory(image, width, height, channels, 4);
+            memFree(image);
+
+            if (data == null) {
+                throw new IllegalStateException("Failed to load texture " + resourcePath + ": " + STBImage.stbi_failure_reason());
+            }
+
+            id = glGenTextures();
+            glBindTexture(GL_TEXTURE_2D, id);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width.get(0), height.get(0), 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+            STBImage.stbi_image_free(data);
+            glBindTexture(GL_TEXTURE_2D, 0);
+        }
+    }
+
+    void bind(int unit) {
+        glActiveTexture(GL_TEXTURE0 + unit);
+        glBindTexture(GL_TEXTURE_2D, id);
+    }
+
+    void dispose() {
+        glDeleteTextures(id);
+    }
+
+    private static ByteBuffer loadResource(String resourcePath) {
+        try (InputStream stream = GlTexture.class.getResourceAsStream(resourcePath)) {
+            if (stream == null) {
+                throw new IllegalArgumentException("Missing resource: " + resourcePath);
+            }
+            byte[] bytes = stream.readAllBytes();
+            ByteBuffer buffer = memAlloc(bytes.length);
+            buffer.put(bytes).flip();
+            return buffer;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load resource: " + resourcePath, e);
+        }
+    }
+}

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/ShaderProgram.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/ShaderProgram.java
@@ -60,6 +60,21 @@ public final class ShaderProgram {
         glUniform1f(loc, v);
     }
 
+    public void setInt(String name, int v) {
+        int loc = glGetUniformLocation(programId, name);
+        if (loc < 0) return;
+        glUniform1i(loc, v);
+    }
+
+    public void setVec4Array(String name, float[] data, int count) {
+        int loc = glGetUniformLocation(programId, name);
+        if (loc < 0) return;
+        FloatBuffer fb = memAllocFloat(count * 4);
+        fb.put(data, 0, count * 4).flip();
+        glUniform4fv(loc, fb);
+        memFree(fb);
+    }
+
     public void dispose() {
         glDeleteProgram(programId);
     }

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/ShaderProgram.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/ShaderProgram.java
@@ -67,7 +67,7 @@ public final class ShaderProgram {
     }
 
     public void setVec4Array(String name, float[] data, int count) {
-        int loc = glGetUniformLocation(programId, name);
+        int loc = glGetUniformLocation(programId, name + "[0]");
         if (loc < 0) return;
         FloatBuffer fb = memAllocFloat(count * 4);
         fb.put(data, 0, count * 4).flip();

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
@@ -1,0 +1,99 @@
+package org.aouessar.platform.lwjgl.renderer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class TextureAtlas {
+    record Region(float u0, float v0, float u1, float v1) {}
+
+    private static final Pattern TILE_ENTRY = Pattern.compile("\"([^\"]+)\"\\s*:\\s*\\{([^}]*)}", Pattern.DOTALL);
+    private final Map<String, Region> regions;
+
+    private TextureAtlas(Map<String, Region> regions) {
+        this.regions = regions;
+    }
+
+    static TextureAtlas load(String resourcePath) {
+        String json = readResource(resourcePath);
+        String tilesBody = extractObject(json, "\"tiles\"");
+
+        Map<String, Region> regions = new HashMap<>();
+        Matcher matcher = TILE_ENTRY.matcher(tilesBody);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            String body = matcher.group(2);
+            float u0 = readFloat(body, "u0");
+            float v0 = readFloat(body, "v0");
+            float u1 = readFloat(body, "u1");
+            float v1 = readFloat(body, "v1");
+            regions.put(name, new Region(u0, v0, u1, v1));
+        }
+
+        if (regions.isEmpty()) {
+            throw new IllegalStateException("Atlas has no tiles: " + resourcePath);
+        }
+
+        return new TextureAtlas(regions);
+    }
+
+    Region region(String name) {
+        Region region = regions.get(name);
+        if (region == null) {
+            throw new IllegalArgumentException("Missing atlas region: " + name);
+        }
+        return region;
+    }
+
+    Region regionOrDefault(String name, Region fallback) {
+        Region region = regions.get(name);
+        return region != null ? region : fallback;
+    }
+
+    private static String readResource(String resourcePath) {
+        try (InputStream stream = TextureAtlas.class.getResourceAsStream(resourcePath)) {
+            if (stream == null) {
+                throw new IllegalArgumentException("Missing resource: " + resourcePath);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read resource: " + resourcePath, e);
+        }
+    }
+
+    private static String extractObject(String json, String keyLiteral) {
+        int keyIndex = json.indexOf(keyLiteral);
+        if (keyIndex < 0) {
+            throw new IllegalStateException("Missing key in atlas: " + keyLiteral);
+        }
+        int braceStart = json.indexOf('{', keyIndex);
+        if (braceStart < 0) {
+            throw new IllegalStateException("Missing opening brace for " + keyLiteral);
+        }
+        int depth = 0;
+        for (int i = braceStart; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c == '{') depth++;
+            if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return json.substring(braceStart + 1, i);
+                }
+            }
+        }
+        throw new IllegalStateException("Unterminated object for " + keyLiteral);
+    }
+
+    private static float readFloat(String body, String key) {
+        Pattern pattern = Pattern.compile("\"%s\"\\s*:\\s*([0-9.]+)".formatted(key));
+        Matcher matcher = pattern.matcher(body);
+        if (!matcher.find()) {
+            throw new IllegalStateException("Missing field " + key + " in atlas entry");
+        }
+        return Float.parseFloat(matcher.group(1));
+    }
+}

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
@@ -29,16 +29,8 @@ final class TextureAtlas {
         while (matcher.find()) {
             String name = matcher.group(1);
             String body = matcher.group(2);
-            float x = readNumber(body, "x");
-            float y = readNumber(body, "y");
-            float w = readNumber(body, "w");
-            float h = readNumber(body, "h");
-
-            float u0 = x / atlasWidth;
-            float u1 = (x + w) / atlasWidth;
-            float v0 = 1f - (y + h) / atlasHeight;
-            float v1 = 1f - y / atlasHeight;
-            regions.put(name, new Region(u0, v0, u1, v1));
+            Region region = parseRegion(body, atlasWidth, atlasHeight);
+            regions.put(name, region);
         }
 
         if (regions.isEmpty()) {
@@ -46,6 +38,33 @@ final class TextureAtlas {
         }
 
         return new TextureAtlas(regions);
+    }
+
+    private static Region parseRegion(String body, float atlasWidth, float atlasHeight) {
+        // Prefer explicit normalized coords if present (atlas.json already stores u0/v0/u1/v1
+        // relative to a top-left origin). Otherwise fall back to x/y/w/h.
+        Float u0 = readNumberOrNull(body, "u0");
+        Float v0 = readNumberOrNull(body, "v0");
+        Float u1 = readNumberOrNull(body, "u1");
+        Float v1 = readNumberOrNull(body, "v1");
+
+        if (u0 != null && v0 != null && u1 != null && v1 != null) {
+            // Atlas JSON uses top-left origin; flip to bottom-left to match OpenGL coords
+            float flippedV0 = 1f - v1;
+            float flippedV1 = 1f - v0;
+            return new Region(u0, flippedV0, u1, flippedV1);
+        }
+
+        float x = readNumber(body, "x");
+        float y = readNumber(body, "y");
+        float w = readNumber(body, "w");
+        float h = readNumber(body, "h");
+
+        float calcU0 = x / atlasWidth;
+        float calcU1 = (x + w) / atlasWidth;
+        float calcV0 = 1f - (y + h) / atlasHeight;
+        float calcV1 = 1f - y / atlasHeight;
+        return new Region(calcU0, calcV0, calcU1, calcV1);
     }
 
     Region region(String name) {
@@ -100,6 +119,15 @@ final class TextureAtlas {
         Matcher matcher = pattern.matcher(body);
         if (!matcher.find()) {
             throw new IllegalStateException("Missing field " + key + " in atlas entry");
+        }
+        return Float.parseFloat(matcher.group(1));
+    }
+
+    private static Float readNumberOrNull(String body, String key) {
+        Pattern pattern = Pattern.compile("\"%s\"\\s*:\\s*([0-9.]+)".formatted(key));
+        Matcher matcher = pattern.matcher(body);
+        if (!matcher.find()) {
+            return null;
         }
         return Float.parseFloat(matcher.group(1));
     }

--- a/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
+++ b/src/main/java/org/aouessar/platform/lwjgl/renderer/TextureAtlas.java
@@ -21,16 +21,23 @@ final class TextureAtlas {
     static TextureAtlas load(String resourcePath) {
         String json = readResource(resourcePath);
         String tilesBody = extractObject(json, "\"tiles\"");
+        float atlasWidth = readNumber(json, "atlasWidth");
+        float atlasHeight = readNumber(json, "atlasHeight");
 
         Map<String, Region> regions = new HashMap<>();
         Matcher matcher = TILE_ENTRY.matcher(tilesBody);
         while (matcher.find()) {
             String name = matcher.group(1);
             String body = matcher.group(2);
-            float u0 = readFloat(body, "u0");
-            float v0 = readFloat(body, "v0");
-            float u1 = readFloat(body, "u1");
-            float v1 = readFloat(body, "v1");
+            float x = readNumber(body, "x");
+            float y = readNumber(body, "y");
+            float w = readNumber(body, "w");
+            float h = readNumber(body, "h");
+
+            float u0 = x / atlasWidth;
+            float u1 = (x + w) / atlasWidth;
+            float v0 = 1f - (y + h) / atlasHeight;
+            float v1 = 1f - y / atlasHeight;
             regions.put(name, new Region(u0, v0, u1, v1));
         }
 
@@ -88,7 +95,7 @@ final class TextureAtlas {
         throw new IllegalStateException("Unterminated object for " + keyLiteral);
     }
 
-    private static float readFloat(String body, String key) {
+    private static float readNumber(String body, String key) {
         Pattern pattern = Pattern.compile("\"%s\"\\s*:\\s*([0-9.]+)".formatted(key));
         Matcher matcher = pattern.matcher(body);
         if (!matcher.find()) {


### PR DESCRIPTION
### Motivation
- Replace solid-color material shading with textured block surfaces driven by an atlas to achieve richer visuals.
- Support distinct top/side materials (e.g. grass top vs grass side) for correct block appearance.
- Provide a way for both near-field meshes and far-field tiles to sample atlas textures consistently from the GPU.

### Description
- Add `GlTexture` to load `atlas.png` via STB and `TextureAtlas` to parse `atlas.json`, and wire them into `GlRenderer` which binds the atlas as `uAtlas` and uploads per-material rects to `uAtlasRects`.
- Extend `ShaderProgram` with `setInt` and `setVec4Array` helpers and update the fragment shader to sample the atlas using per-vertex UVs and atlas rects instead of the previous procedural `materialColor` logic.
- Add a new material id `GRASS_SIDE` to `BlockId` and update `GreedyMesher` to assign `GRASS_SIDE` for grass block sides while preserving dirt for appropriate bottom faces.
- Modify `FarTileBuilder` to emit world X/Z into vertex UVs (for atlas sampling on far meshes) and keep per-vertex material IDs for the far mesh.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae50b624c8324af4b63687025d92a)